### PR TITLE
RecordTrail class properly loaded after original's (PaperTrail#RecordTrail)

### DIFF
--- a/lib/mongo_trails.rb
+++ b/lib/mongo_trails.rb
@@ -3,6 +3,7 @@
 require 'paper_trail'
 require 'paper_trail/version_concern'
 require 'paper_trail/model_config'
+require 'paper_trail/record_trail'
 
 require 'mongo_trails/config'
 require 'mongo_trails/model_config'

--- a/lib/mongo_trails/record_trail.rb
+++ b/lib/mongo_trails/record_trail.rb
@@ -13,11 +13,14 @@ module PaperTrail
     def record_destroy(recording_order)
       return unless enabled? && !@record.new_record?
 
-      in_after_callback = recording_order == "after"
+      in_after_callback = recording_order == 'after'
       event = Events::Destroy.new(@record, in_after_callback)
       data = event.data.merge(data_for_destroy)
 
-      @record.class.paper_trail.version_class.new(data).save_version
+      version = @record.class.paper_trail.version_class.new(data)
+      return if exceeds_record_size_limit?(version)
+
+      version.save_version
     end
 
     def record_update(force:, in_after_callback:, is_touch:)

--- a/mongo_trails.gemspec
+++ b/mongo_trails.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name = 'mongo_trails'
-  s.version = '12.0'
+  s.version = '12.0.1'
   s.platform = Gem::Platform::RUBY
   s.summary = 'PaperTrail addon to store versions in MongoDB'
   s.description = <<~DSC


### PR DESCRIPTION
## Overview
Problem: PaperTrail#RecordTrail class was being loaded after the one with custom methods. So it wasn't properly working when you use it in a rails project. 

## Details
* Fix: required 'paper_trail/record_trail' before 'mongo_trails/record_trail'
* Fix: check to save version before saving version deleted
* Update: increased gemspec version

