### PR TITLE
Force UTF-8 to support emojis in keys or values of a jsonb

### DIFF
--- a/lib/mongo_trails/mongo_support/version.rb
+++ b/lib/mongo_trails/mongo_support/version.rb
@@ -118,7 +118,7 @@ module MongoTrails
     private
 
     def force_utf8(value)
-      value.dup.force_encoding('UTF-8') if value.respond_to?(:force_encoding)
+      value.respond_to?(:force_encoding) ? value.dup.force_encoding('UTF-8') : value
     end
 
     def parser

--- a/lib/mongo_trails/mongo_support/version.rb
+++ b/lib/mongo_trails/mongo_support/version.rb
@@ -108,14 +108,18 @@ module MongoTrails
     end
 
     def unescape_value(value)
-      value&.deep_transform_keys { |key| parser.unescape(key) }
+      value&.deep_transform_keys { |key| parser.unescape(force_utf8(key)) }
     end
 
     def escape_value(value)
-      value&.deep_transform_keys { |key| parser.escape(key.to_s, /[$.]/) }
+      value&.deep_transform_keys { |key| parser.escape(force_utf8(key.to_s), /[$.]/) }
     end
 
     private
+
+    def force_utf8(value)
+      value.dup.force_encoding('UTF-8') if value.respond_to?(:force_encoding)
+    end
 
     def parser
       @parser ||= URI::Parser.new

--- a/mongo_trails.gemspec
+++ b/mongo_trails.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name = 'mongo_trails'
-  s.version = '12.0.2'
+  s.version = '12.0.3'
   s.platform = Gem::Platform::RUBY
   s.summary = 'PaperTrail addon to store versions in MongoDB'
   s.description = <<~DSC


### PR DESCRIPTION
## Overview
When saving a jsonb column with emojis was not parsing correctly and was giving a: 
`ArgumentError: invalid byte sequence in US-ASCII`

with this fix it works:
<img width="690" alt="image" src="https://github.com/moskvin/mongo_trails/assets/109097544/d077c045-f7b3-45e4-bdfe-39769bcd6f98">


## DS reference
🐛 https://app.rollbar.com/a/donesafe/fix/item/donesafe/256874
⚙️ https://product.donesafe.com/module_records/26376