### PR TITLE
Better after commit handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ar_shard.gemspec
 gemspec
 
-gem 'after_commit_everywhere'
 gem 'appraisal', '~> 2.3'
 gem 'minitest', '~> 5.0'
 gem 'rake', '~> 13.0'

--- a/lib/mongo_trails.rb
+++ b/lib/mongo_trails.rb
@@ -9,6 +9,7 @@ require 'mongo_trails/config'
 require 'mongo_trails/model_config'
 require 'mongo_trails/version_concern'
 require 'mongo_trails/record_trail'
+require 'mongo_trails/events/base'
 
 ActiveSupport.on_load(:active_record) do
   require 'mongo_trails/mongo_support/version'

--- a/lib/mongo_trails/events/base.rb
+++ b/lib/mongo_trails/events/base.rb
@@ -1,0 +1,23 @@
+module PaperTrail
+  module Events
+    class Base
+      def load_changes_in_latest_version
+        changes = if ['PaperTrail::Events::Create', 'PaperTrail::Events::Update'].include?(self.class.to_s)
+          @record.paper_trail_accumulated_versions
+        elsif @in_after_callback
+          @record.saved_changes
+        else
+          @record.changes
+        end
+
+        changes = @record.paper_trail_accumulated_versions 
+
+        # this is for checking the change in a jsonb column
+        changes.delete_if { |_k, v|
+          v.is_a?(Array) && v.size > 1 && v.last.is_a?(Hash) && v.uniq.size == 1
+        }
+        changes
+      end
+    end
+  end
+end

--- a/lib/mongo_trails/events/base.rb
+++ b/lib/mongo_trails/events/base.rb
@@ -2,7 +2,7 @@ module PaperTrail
   module Events
     class Base
       def load_changes_in_latest_version
-        changes = if ['PaperTrail::Events::Create', 'PaperTrail::Events::Update'].include?(self.class.to_s)
+        changes = if ['PaperTrail::Events::Create', 'PaperTrail::Events::Update'].include?(self.class.to_s) && @record.respond_to?(:paper_trail_accumulated_versions)
           @record.paper_trail_accumulated_versions
         elsif @in_after_callback
           @record.saved_changes
@@ -10,13 +10,16 @@ module PaperTrail
           @record.changes
         end
 
-        changes = @record.paper_trail_accumulated_versions 
+        safe_changes = changes ? changes.dup : {}
 
-        # this is for checking the change in a jsonb column
-        changes.delete_if { |_k, v|
-          v.is_a?(Array) && v.size > 1 && v.last.is_a?(Hash) && v.uniq.size == 1
-        }
-        changes
+        safe_changes.delete_if do |_k, v|
+          next unless v.is_a?(Array)
+          next if v.size <= 1
+
+          v.uniq.size == 1
+        end
+        
+        safe_changes
       end
     end
   end

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -35,13 +35,17 @@ module PaperTrail
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
 
-          saved_changes.each do |k, v|
+          saved_changes.each do |k, new_value|
             old_value = @paper_trail_accumulated_versions[k.to_sym]
-            @paper_trail_accumulated_versions[k.to_sym] = if old_value.present? && old_value.is_a?(Array) && old_value.size > 1 # rubocop:disable Layout/LineLength
-                                                            [old_value.first, v.last]
-                                                          else
-                                                            v
-                                                          end
+            @paper_trail_accumulated_versions[k.to_sym] = paper_trail_accumulated_version_value(old_value, new_value)
+          end
+        end
+
+        def paper_trail_accumulated_version_value(old_value, new_value)
+          if old_value.present? && old_value.is_a?(Array) && old_value.size > 1 && new_value.is_a?(Array) && new_value.size > 1 # rubocop:disable Layout/LineLength
+            [old_value.first, new_value.last]
+          else
+            new_value
           end
         end
 

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -34,8 +34,14 @@ module PaperTrail
 
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
+
           saved_changes.each do |k, v|
-            @paper_trail_accumulated_versions[k.to_sym] = v
+            old_value = @paper_trail_accumulated_versions[k.to_sym]
+            @paper_trail_accumulated_versions[k.to_sym] = if old_value.present? && old_value.is_a?(Array) && old_value.size > 1 # rubocop:disable Layout/LineLength
+                                                            [old_value.first, v.last]
+                                                          else
+                                                            v
+                                                          end
           end
         end
 
@@ -60,7 +66,7 @@ module PaperTrail
       append_option_uniquely(:on, :create)
     end
 
-    def on_update
+    def on_update # rubocop:disable Metrics/MethodLength
       @model_class.class_eval do
         before_save :paper_trail_reset_timestamps_if_needed
         after_commit :paper_trail_on_record_update, on: :update
@@ -86,6 +92,21 @@ module PaperTrail
       end
 
       append_option_uniquely(:on, :update)
+    end
+
+    def on_destroy(_recording_order = 'before')
+      @model_class.class_eval do
+        after_commit :paper_trail_on_record_destroy_in_transaction, on: :destroy
+
+        private
+
+        def paper_trail_on_record_destroy_in_transaction
+          paper_trail.record_destroy('before')
+          paper_trail_clear_accumulated_versions
+        end
+      end
+
+      append_option_uniquely(:on, :destroy)
     end
   end
 end

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -14,5 +14,78 @@ module PaperTrail
         end
       RUBY
     end
+
+
+    alias_method :setup_callbacks, :setup_callbacks_from_options
+
+    def setup_callbacks_from_options(options)
+      on_save
+      setup_callbacks(options)
+    end
+
+    def on_save
+      @model_class.class_eval do
+        attr_reader :paper_trail_accumulated_versions
+
+        after_save :paper_trail_accumulate_versions
+        after_rollback :paper_trail_clear_accumulated_versions
+
+        private
+
+        def paper_trail_accumulate_versions
+          @paper_trail_accumulated_versions ||= {}
+          saved_changes.each do |k, v|
+            @paper_trail_accumulated_versions[k.to_sym] = v
+          end
+        end
+
+        def paper_trail_clear_accumulated_versions
+          @paper_trail_accumulated_versions = nil
+        end
+      end
+    end
+
+    def on_create
+      @model_class.class_eval do
+        after_commit :paper_trail_on_record_create_in_transaction, on: :create
+
+        private
+
+        def paper_trail_on_record_create_in_transaction
+          paper_trail.record_create if paper_trail.save_version?
+          paper_trail_clear_accumulated_versions
+        end
+      end
+
+      append_option_uniquely(:on, :create)
+    end
+
+    def on_update
+      @model_class.class_eval do
+        before_save :paper_trail_reset_timestamps_if_needed
+        after_commit :paper_trail_on_record_update, on: :update
+
+        private
+
+        def paper_trail_reset_timestamps_if_needed
+          paper_trail.reset_timestamp_attrs_for_update_if_needed
+        end
+
+        def paper_trail_on_record_update
+          if paper_trail.save_version?
+            paper_trail.record_update(
+              force: false,
+              in_after_callback: true,
+              is_touch: false
+            )
+          end
+
+          paper_trail.clear_version_instance
+          paper_trail_clear_accumulated_versions
+        end
+      end
+
+      append_option_uniquely(:on, :update)
+    end
   end
 end

--- a/lib/mongo_trails/mongo_support/version.rb
+++ b/lib/mongo_trails/mongo_support/version.rb
@@ -52,7 +52,6 @@ module MongoTrails
     include PaperTrail::VersionConcern
     include Mongoid::Document
     include Mongoid::Autoinc
-    include AfterCommitEverywhere
 
     store_in collection: -> { "#{MongoTrails::Version.prefix_map}_versions" }
 

--- a/lib/mongo_trails/mongo_support/version.rb
+++ b/lib/mongo_trails/mongo_support/version.rb
@@ -2,7 +2,6 @@
 
 require 'mongoid'
 require 'autoinc'
-require 'after_commit_everywhere'
 
 begin
   require 'sidekiq'
@@ -71,15 +70,11 @@ module MongoTrails
     increments :integer_id, scope: -> { MongoTrails::Version.prefix_map }
 
     def save_version
-      after_commit do
-        defined?(Sidekiq) && PaperTrail.config.enable_sidekiq ? async_save! : save
-      end
+      defined?(Sidekiq) && PaperTrail.config.enable_sidekiq ? async_save! : save
     end
 
     def save_version!
-      after_commit do
-        defined?(Sidekiq) && PaperTrail.config.enable_sidekiq ? async_save! : save!
-      end
+      defined?(Sidekiq) && PaperTrail.config.enable_sidekiq ? async_save! : save!
     end
 
     def initialize(data)

--- a/mongo_trails.gemspec
+++ b/mongo_trails.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name = 'mongo_trails'
-  s.version = '13.0.0'
+  s.version = '13.0.1'
   s.platform = Gem::Platform::RUBY
   s.summary = 'PaperTrail addon to store versions in MongoDB'
   s.description = <<~DSC

--- a/test/events_base_test.rb
+++ b/test/events_base_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module PaperTrail
+  module Events
+    # Simulate subclass inheritance
+    class Create < Base; end
+    class Update < Base; end
+    class Destroy < Base; end
+  end
+end
+
+# Dummy ActiveRecord model that responds to paper_trail_accumulated_versions
+# --- The Test Suite ---
+class DummyModelWithAccumulated
+  attr_accessor :changes, :saved_changes
+
+  def paper_trail_accumulated_versions
+    { 'title' => ['Draft', 'Published'] }
+  end
+end
+
+# Dummy ActiveRecord model missing paper_trail_accumulated_versions
+class DummyModelStandard
+  attr_accessor :changes, :saved_changes
+end
+
+class PaperTrailEventsBaseTest < Minitest::Test
+  def setup
+    @user = User.new
+    @user.instance_variable_set('@paper_trail_accumulated_versions', {
+                                  'title' => %w[Draft Published]
+    })
+    @record_with_accumulated = DummyModelWithAccumulated.new
+    @record_standard = DummyModelStandard.new
+  end
+
+  def test_uses_accumulated_versions_on_create
+    event = PaperTrail::Events::Create.new(@record_with_accumulated, true)
+    result = event.load_changes_in_latest_version
+
+    assert_equal({ 'title' => ['Draft', 'Published'] }, result)
+  end
+
+  def test_uses_accumulated_versions_on_update
+    event = PaperTrail::Events::Update.new(@record_with_accumulated, true, false, nil)
+    result = event.load_changes_in_latest_version
+
+    assert_equal({ 'title' => %w[Draft Published] }, result)
+  end
+  #
+  def test_falls_back_if_record_does_not_respond_to_accumulated_versions
+    @record_standard.saved_changes = { 'name' => ['Old', 'New'] }
+    event = PaperTrail::Events::Update.new(@record_standard, true, false, nil)
+    result = event.load_changes_in_latest_version
+    assert_equal({ 'name' => ['Old', 'New'] }, result)
+  end
+  
+  def test_uses_saved_changes_when_in_after_callback
+    @record_standard.saved_changes = { 'status' => ['Pending', 'Active'] }
+    @record_standard.changes = { 'should_ignore' => [1, 2] }
+
+    # Event is Destroy (not Create/Update) so it skips the first IF branch
+    event = PaperTrail::Events::Destroy.new(@record_standard, true)
+
+    result = event.load_changes_in_latest_version
+    assert_equal({ 'status' => ['Pending', 'Active'] }, result)
+  end
+  #
+  def test_uses_standard_changes_as_default_fallback
+    @record_standard.changes = { 'score' => [10, 20] }
+
+    event = PaperTrail::Events::Destroy.new(@record_standard, false)
+
+    result = event.load_changes_in_latest_version
+    assert_equal({ 'score' => [10, 20] }, result)
+  end
+  
+  def test_filters_out_unmodified_jsonb_columns
+    @record_standard.changes = {
+      'valid_change' => ['Old String', 'New String'],
+      'jsonb_no_change' => [{ 'key' => 'val' }, { 'key' => 'val' }],
+      'jsonb_actual_change' => [{ 'key' => 'val' }, { 'key' => 'new_val' }]
+    }
+
+    event = PaperTrail::Events::Destroy.new(@record_standard, false)
+    result = event.load_changes_in_latest_version
+
+    assert_includes result.keys, 'valid_change'
+    assert_includes result.keys, 'jsonb_actual_change'
+    refute_includes result.keys, 'jsonb_no_change', 'Identical JSONB hashes should be filtered out'
+  end
+end

--- a/test/transaction_handling_test.rb
+++ b/test/transaction_handling_test.rb
@@ -28,15 +28,50 @@ class TransactionHandlingTest < Minitest::Test
     ActiveRecord::Base.transaction do
       user.update!(name: 'Arnold Schwarzenegger')
       user.update!(title: 'Governor')
+      user.update!(name: 'Chuck Norris')
       user.update!(name: 'Jackie Chan')
     end
 
-    assert_equal 4, user.versions.count
-    assert_equal({ 'name' => ['John Doe', 'Arnold Schwarzenegger'] },
-                 user.versions.where(event: 'update')[0].object_changes)
-    assert_equal({ 'title' => [nil, 'Governor'] }, user.versions.where(event: 'update')[1].object_changes)
-    assert_equal({ 'name' => ['Arnold Schwarzenegger', 'Jackie Chan'] },
-                 user.versions.where(event: 'update')[2].object_changes)
+    assert_equal 2, user.versions.count
+    assert_equal %w[create update], user.versions.pluck(:event)
+    versions = user.versions
+    assert_equal(versions.last.event, 'update')
+    assert_equal(versions.last.object_changes.keys, %w[name title])
+    assert_equal(['John Doe', 'Jackie Chan'], versions.last.object_changes['name'])
+    assert_equal([nil, 'Governor'], versions.last.object_changes['title'])
+  end
+
+  def test_on_update_that_did_not_changed_the_name
+    user = User.create!(name: 'John Doe')
+    assert_equal 1, user.versions.count
+
+    ActiveRecord::Base.transaction do
+      user.update!(name: 'Jackie Chan')
+      user.update!(name: 'Chuck Norris')
+      user.update!(name: 'John Doe')
+    end
+
+    assert_equal ['create'], user.versions.pluck(:event)
+    assert_equal 1, user.versions.count
+    assert_equal 'create', user.versions.first.event
+  end
+
+  def test_on_name_not_changed_but_title_changed
+    user = User.create!(name: 'John Doe')
+    assert_equal 1, user.versions.count
+
+    ActiveRecord::Base.transaction do
+      user.update!(name: 'Jackie Chan')
+      user.update!(title: 'Governor')
+      user.update!(name: 'John Doe')
+    end
+
+    assert_equal 2, user.versions.count
+    assert_equal %w[create update], user.versions.pluck(:event)
+    versions = user.versions
+    assert_equal(versions.last.event, 'update')
+    assert_equal(versions.last.object_changes.keys, %w[title])
+    assert_equal([nil, 'Governor'], versions.last.object_changes['title'])
   end
 
   def test_on_update_does_not_create_version_if_transaction_not_completed


### PR DESCRIPTION
Summary

This PR shifts our versioning logic from after_create/after_update to after_commit and introduces an accumulation mechanism for model changes. This ensures that audit logs (PaperTrail) remain accurate even when subsequent callbacks trigger a model reload.
The Problem

Currently, we rely on standard Active Record lifecycle hooks. However, we've identified an issue where:

    A record is saved, and changes are tracked.

    A subsequent callback (like a before_commit or an unrelated after_save) triggers a reload on the record.

    This reload flushes the saved_changes hash.

    When the versioning logic finally runs, it sees an "empty" change set, causing PaperTrail to miss updates or fail to record the history correctly.

The Solution

    Shift to after_commit: Moved the trigger for version creation to the end of the database transaction to ensure the data is fully persisted.

    Accumulated Changes: Introduced a temporary state tracker that captures and "holds" changes throughout the transaction.

    Buffer Release: This accumulated state is only cleared once the create_version callback has successfully executed.

Key Changes

    Lifecycle Hooks: Swapped :after_create and :after_update for :after_commit, on: [:create, :update].

    Change Tracking: Implemented a buffer to store saved_changes before they can be wiped by middle-layer reloads.