### PR TITLE
Assigns the whodunnit on record save to be used later in after_commit

### DIFF
--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -25,7 +25,7 @@ module PaperTrail
 
     def on_save
       @model_class.class_eval do
-        attr_reader :paper_trail_accumulated_versions
+        attr_reader :paper_trail_accumulated_versions, :paper_trail_whodunnit
 
         after_save :paper_trail_accumulate_versions
         after_rollback :paper_trail_clear_accumulated_versions
@@ -34,6 +34,7 @@ module PaperTrail
 
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
+          @paper_trail_whodunnit = PaperTrail.request.whodunnit
 
           saved_changes.each do |k, new_value|
             old_value = @paper_trail_accumulated_versions[k.to_sym]

--- a/lib/mongo_trails/record_trail.rb
+++ b/lib/mongo_trails/record_trail.rb
@@ -4,6 +4,7 @@ module PaperTrail
       return unless enabled?
 
       build_version_on_create(in_after_callback: true).tap do |version|
+        assign_whodunnit!(version)
         return if exceeds_record_size_limit?(version)
 
         version.save_version!
@@ -18,6 +19,7 @@ module PaperTrail
       data = event.data.merge(data_for_destroy)
 
       version = @record.class.paper_trail.version_class.new(data)
+      assign_whodunnit!(version)
       return if exceeds_record_size_limit?(version)
 
       version.save_version
@@ -31,6 +33,7 @@ module PaperTrail
         in_after_callback: in_after_callback,
         is_touch: is_touch
       )
+      assign_whodunnit!(version)
       return unless version && !exceeds_record_size_limit?(version)
 
       version.save_version
@@ -43,12 +46,19 @@ module PaperTrail
       data = event.data.merge(data_for_update_columns)
       versions_assoc = @record.send(@record.class.versions_association_name)
       version = versions_assoc.new(data)
+      assign_whodunnit!(version)
       return if exceeds_record_size_limit?(version)
 
       version.save_version
     end
 
     private
+
+    def assign_whodunnit!(version)
+      return unless @record.respond_to?(:paper_trail_whodunnit) && @record.paper_trail_whodunnit.present?
+
+      version.whodunnit = @record.paper_trail_whodunnit.to_s
+    end
 
     def exceeds_record_size_limit?(version)
       size_limit = PaperTrail.config.mongo_trails_config&.dig(:record_size_limit)

--- a/mongo_trails.gemspec
+++ b/mongo_trails.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name = 'mongo_trails'
-  s.version = '13.0.1'
+  s.version = '13.0.2'
   s.platform = Gem::Platform::RUBY
   s.summary = 'PaperTrail addon to store versions in MongoDB'
   s.description = <<~DSC

--- a/mongo_trails.gemspec
+++ b/mongo_trails.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name = 'mongo_trails'
-  s.version = '13.0.2'
+  s.version = '13.0.1'
   s.platform = Gem::Platform::RUBY
   s.summary = 'PaperTrail addon to store versions in MongoDB'
   s.description = <<~DSC

--- a/test/user_whodunnit_test.rb
+++ b/test/user_whodunnit_test.rb
@@ -2,36 +2,25 @@ require 'test_helper'
 
 class UserWhodunnitTest < ActiveSupport::TestCase
   setup do
-    # Ensure PaperTrail is enabled for tests (often turned off by default in test_helper)
     PaperTrail.request.enabled = true
-    
-    # Create the base record to update
     @user = User.create!(title: 'citizen')
   end
 
   teardown do
-    # Clean up global state so it doesn't leak into other test files
     PaperTrail.request.whodunnit = nil
   end
 
   test "preserves block whodunnit for versions created inside a transaction" do
-    # 1. Set the baseline context
     PaperTrail.request.whodunnit = '4'
 
-    # 2. Execute your specific block structure
     User.transaction do
-      # Swap `PaperTrail.request.with` with your custom `Papertrail.with` if you have a wrapper
       PaperTrail.request.with(whodunnit: 'System') do
         @user.update!(title: 'president')
       end
     end
 
-    # 3. Assert the global state successfully reverted back to '4' after the block
     assert_equal '4', PaperTrail.request.whodunnit, "Global whodunnit should revert back to 4"
-
-    # 4. Assert the version correctly captured 'System'
     last_version = @user.versions.last
-    
     assert_not_nil last_version, "A PaperTrail version should have been created"
     assert_equal 'System', last_version.whodunnit, "The version whodunnit should be 'System', not '4'"
   end

--- a/test/user_whodunnit_test.rb
+++ b/test/user_whodunnit_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class UserWhodunnitTest < ActiveSupport::TestCase
+  setup do
+    # Ensure PaperTrail is enabled for tests (often turned off by default in test_helper)
+    PaperTrail.request.enabled = true
+    
+    # Create the base record to update
+    @user = User.create!(title: 'citizen')
+  end
+
+  teardown do
+    # Clean up global state so it doesn't leak into other test files
+    PaperTrail.request.whodunnit = nil
+  end
+
+  test "preserves block whodunnit for versions created inside a transaction" do
+    # 1. Set the baseline context
+    PaperTrail.request.whodunnit = '4'
+
+    # 2. Execute your specific block structure
+    User.transaction do
+      # Swap `PaperTrail.request.with` with your custom `Papertrail.with` if you have a wrapper
+      PaperTrail.request.with(whodunnit: 'System') do
+        @user.update!(title: 'president')
+      end
+    end
+
+    # 3. Assert the global state successfully reverted back to '4' after the block
+    assert_equal '4', PaperTrail.request.whodunnit, "Global whodunnit should revert back to 4"
+
+    # 4. Assert the version correctly captured 'System'
+    last_version = @user.versions.last
+    
+    assert_not_nil last_version, "A PaperTrail version should have been created"
+    assert_equal 'System', last_version.whodunnit, "The version whodunnit should be 'System', not '4'"
+  end
+end


### PR DESCRIPTION
if we are in a transaction 
```ruby
transaction do
 # current whodunnit is 4
  Papertrail.with(whodunnit: 'System') do
    User.update(title: 'president')
  end
  # after this the whodunnit whould be 4
end

# => result should be that the user last version whodunnit should be 'System' not '4'
```

then the User version whodunnit should be 'System' no reason for it to be '4' since the code was executed in the block, that's what this pr addresses.
