### PR TITLE
Propagate paper_trail state across deduplicated transaction instances

### DIFF
--- a/lib/mongo_trails.rb
+++ b/lib/mongo_trails.rb
@@ -10,6 +10,7 @@ require 'mongo_trails/model_config'
 require 'mongo_trails/version_concern'
 require 'mongo_trails/record_trail'
 require 'mongo_trails/events/base'
+require 'mongo_trails/callback_propagation'
 
 ActiveSupport.on_load(:active_record) do
   require 'mongo_trails/mongo_support/version'

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -54,5 +54,6 @@ module PaperTrail
 end
 
 ActiveSupport.on_load(:active_record) do
+  require 'active_record/connection_adapters/abstract/transaction'
   ActiveRecord::ConnectionAdapters::Transaction.prepend(PaperTrail::CallbackPropagation)
 end

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -55,5 +55,13 @@ end
 
 ActiveSupport.on_load(:active_record) do
   require 'active_record/connection_adapters/abstract/transaction'
-  ActiveRecord::ConnectionAdapters::Transaction.prepend(PaperTrail::CallbackPropagation)
+
+  # `prepare_instances_to_run_callbacks_on` and the
+  # `run_commit_callbacks_on_first_saved_instances_in_transaction` class attribute were
+  # introduced together in Rails 7.1. On older Rails the dedup logic is inline in
+  # `commit_records` and not configurable — skip the prepend so we don't shadow a method
+  # the gem doesn't need and don't reference a missing class attribute.
+  if ActiveRecord::ConnectionAdapters::Transaction.private_method_defined?(:prepare_instances_to_run_callbacks_on)
+    ActiveRecord::ConnectionAdapters::Transaction.prepend(PaperTrail::CallbackPropagation)
+  end
 end

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -54,10 +54,15 @@ module PaperTrail
       return if from_changes.blank?
 
       from.send(:paper_trail_within_writer_request) do
-        if from.previously_new_record?
+        # Mirror Rails' own create-vs-update determination for after_commit callbacks
+        # (ActiveRecord::Transactions#transaction_include_any_action?): a record created in this
+        # transaction is a `create` even if it was updated again afterwards. `previously_new_record?`
+        # only reflects the LAST save, so it mislabels create-then-update-in-one-transaction as an
+        # update; `_new_record_before_last_commit` is the transaction-aware flag Rails uses.
+        if from.persisted? && from._new_record_before_last_commit
           from.paper_trail.record_create if from.paper_trail.save_version?
-        else
-          from.paper_trail.record_update(force: false, in_after_callback: true, is_touch: false) if from.paper_trail.save_version? # rubocop:disable Style/IfUnlessModifier,Layout/LineLength
+        elsif from.paper_trail.save_version?
+          from.paper_trail.record_update(force: false, in_after_callback: true, is_touch: false)
         end
       end
     end

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -1,33 +1,59 @@
 # frozen_string_literal: true
 
 module PaperTrail
-  # mongo_trails captures paper_trail state (whodunnit + accumulated changes) on the saved
-  # instance via after_save (see ModelConfig#paper_trail_accumulate_versions), then reads it
-  # back from after_commit to build the version (RecordTrail#assign_whodunnit!).
+  # mongo_trails captures paper_trail state on the saved instance via after_save (see
+  # ModelConfig#paper_trail_accumulate_versions): the accumulated field changes plus a snapshot
+  # of the request context (whodunnit, controller_info, event_group_uuid). It reads that state
+  # back from after_commit to build the version.
   #
-  # When the same record is saved more than once in a transaction through different
-  # in-memory instances, Rails 7.1+ picks ONE instance to fire after_commit on and discards
-  # the rest — so any state captured on the discarded instance (e.g. inside a
-  # `PaperTrail.request.with(whodunnit: ...)` block) is lost.
+  # When the same record is saved more than once in a transaction through different in-memory
+  # instances, Rails 7.1+ picks ONE instance to fire after_commit on and discards the rest — so
+  # any state captured on the discarded instances is lost.
   #
-  # Rails' built-in fix propagates `_new_record_before_last_commit` from the earlier
-  # candidate to the later one (active_record/connection_adapters/abstract/transaction.rb).
-  # We mirror that for paper_trail state, in the opposite direction: when
-  # `run_commit_callbacks_on_first_saved_instances_in_transaction = true` causes Rails to
-  # KEEP the earlier candidate and DROP a later instance, copy the later instance's
-  # `@paper_trail_whodunnit` and merge its `@paper_trail_accumulated_versions` onto the
-  # kept candidate before discarding it.
+  # Rails' built-in fix propagates `_new_record_before_last_commit` from the earlier candidate
+  # to the later one (active_record/connection_adapters/abstract/transaction.rb). We mirror that
+  # for paper_trail state, in the opposite direction: when
+  # `run_commit_callbacks_on_first_saved_instances_in_transaction = true` causes Rails to KEEP
+  # the earlier candidate and DROP later instances, we:
+  #
+  #   * merge every discarded instance's accumulated field changes onto the kept candidate, and
+  #   * copy the captured request context (whodunnit + controller_info + event_group_uuid) of
+  #     the LAST writer onto the kept candidate.
+  #
+  # The request context is NOT taken from "whichever instance was enrolled in the transaction
+  # last": instances are enrolled in first-save order, so when the kept (first) instance is
+  # itself re-saved AFTER a later instance, naively copying the later instance's state would
+  # clobber the kept instance's own, newer state and attribute the version to the wrong writer
+  # (e.g. the wrong automation). Instead we read the full, chronologically-ordered list of saves
+  # to find the genuinely LAST writer of each record.
   module CallbackPropagation
     private
 
+    # Captured request state to copy from the last writer onto the kept instance. Whodunnit is
+    # read back by `RecordTrail#assign_whodunnit!`; the rest is restored around the version
+    # build by `ModelConfig#paper_trail_within_writer_request`.
+    PAPER_TRAIL_STATE_IVARS = %i[
+      @paper_trail_whodunnit
+      @paper_trail_controller_info
+      @paper_trail_event_group_uuid
+    ].freeze
+
     def prepare_instances_to_run_callbacks_on(records)
+      # `records` here is the de-duplicated list Rails passes in (`unique_records`). The full,
+      # ordered list of saves is `self.records`: a record saved through several in-memory
+      # instances — or the same instance re-saved — appears once per save, in chronological
+      # order. We use it to find the instance that performed the LAST save of each record, so
+      # the version is attributed to it rather than to whichever instance happened to be
+      # enrolled in the transaction last.
+      last_writers = last_writer_by_record(self.records)
+
       records.each_with_object({}) do |record, candidates|
         next unless record.trigger_transactional_callbacks?
 
         earlier_saved_candidate = candidates[record]
 
         if earlier_saved_candidate && record.class.run_commit_callbacks_on_first_saved_instances_in_transaction
-          copy_paper_trail_state(from: record, to: earlier_saved_candidate)
+          merge_accumulated_versions(from: record, to: earlier_saved_candidate)
           next
         end
 
@@ -36,13 +62,46 @@ module PaperTrail
         record._new_record_before_last_commit = true if earlier_saved_candidate&._new_record_before_last_commit
 
         candidates[record] = record
+      end.tap do |candidates|
+        # The kept instance runs after_commit and builds the version. When it is not itself the
+        # last writer, copy the last writer's captured request state (whodunnit, controller_info,
+        # event_group_uuid) onto it so the version reflects the writer it belongs to.
+        candidates.each_value do |kept|
+          next unless kept.class.run_commit_callbacks_on_first_saved_instances_in_transaction
+
+          copy_paper_trail_state(from: last_writers[kept], to: kept)
+        end
+      end
+    end
+
+    # Build { record => last_saved_instance } honouring chronological save order. Later entries
+    # overwrite earlier ones, so the final value is the instance that saved the record last.
+    def last_writer_by_record(all_saves)
+      return {} unless all_saves
+
+      all_saves.each_with_object({}) do |record, acc|
+        next unless record.respond_to?(:paper_trail_whodunnit)
+
+        acc[record] = record
       end
     end
 
     def copy_paper_trail_state(from:, to:)
-      return unless from.respond_to?(:paper_trail_whodunnit) && to.respond_to?(:paper_trail_whodunnit)
+      return if from.nil? || from.equal?(to)
+      return unless to.respond_to?(:paper_trail_whodunnit)
 
-      to.instance_variable_set(:@paper_trail_whodunnit, from.paper_trail_whodunnit) if from.paper_trail_whodunnit
+      PAPER_TRAIL_STATE_IVARS.each do |ivar|
+        next unless from.instance_variable_defined?(ivar)
+
+        value = from.instance_variable_get(ivar)
+        next if value.blank?
+
+        to.instance_variable_set(ivar, value)
+      end
+    end
+
+    def merge_accumulated_versions(from:, to:)
+      return unless from.respond_to?(:paper_trail_accumulated_versions) && to.respond_to?(:paper_trail_accumulated_versions)
 
       from_changes = from.paper_trail_accumulated_versions
       return if from_changes.blank?

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -60,6 +60,14 @@ module PaperTrail
         # attributed to the writer it belongs to. The context shape is opaque here — the model
         # owns capture/adopt (ModelConfig) so this stays agnostic of any app-specific state.
         candidates.each_value do |kept|
+          # `candidates` can include non-ActiveRecord entries enrolled in the transaction by
+          # other gems (e.g. after_commit_everywhere's Wrap). Those respond neither to
+          # PaperTrail's capture/adopt API nor to the AR-only
+          # `run_commit_callbacks_on_first_saved_instances_in_transaction` class attribute, so
+          # touching that attribute on them raises NoMethodError and aborts the commit. Only
+          # PaperTrail-enabled records can adopt writer state — gate on that before reading the
+          # AR class attribute.
+          next unless kept.respond_to?(:paper_trail_adopt_state, true)
           next unless kept.class.run_commit_callbacks_on_first_saved_instances_in_transaction
 
           adopt_last_writer_state(into: kept, from: last_writers[kept])

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  # mongo_trails captures paper_trail state (whodunnit + accumulated changes) on the saved
+  # instance via after_save (see ModelConfig#paper_trail_accumulate_versions), then reads it
+  # back from after_commit to build the version (RecordTrail#assign_whodunnit!).
+  #
+  # When the same record is saved more than once in a transaction through different
+  # in-memory instances, Rails 7.1+ picks ONE instance to fire after_commit on and discards
+  # the rest — so any state captured on the discarded instance (e.g. inside a
+  # `PaperTrail.request.with(whodunnit: ...)` block) is lost.
+  #
+  # Rails' built-in fix propagates `_new_record_before_last_commit` from the earlier
+  # candidate to the later one (active_record/connection_adapters/abstract/transaction.rb).
+  # We mirror that for paper_trail state, in the opposite direction: when
+  # `run_commit_callbacks_on_first_saved_instances_in_transaction = true` causes Rails to
+  # KEEP the earlier candidate and DROP a later instance, copy the later instance's
+  # `@paper_trail_whodunnit` and merge its `@paper_trail_accumulated_versions` onto the
+  # kept candidate before discarding it.
+  module CallbackPropagation
+    private
+
+    def prepare_instances_to_run_callbacks_on(records)
+      records.each_with_object({}) do |record, candidates|
+        next unless record.trigger_transactional_callbacks?
+
+        earlier_saved_candidate = candidates[record]
+
+        if earlier_saved_candidate && record.class.run_commit_callbacks_on_first_saved_instances_in_transaction
+          copy_paper_trail_state(from: record, to: earlier_saved_candidate)
+          next
+        end
+
+        next if earlier_saved_candidate&.destroyed? && !record.destroyed?
+
+        record._new_record_before_last_commit = true if earlier_saved_candidate&._new_record_before_last_commit
+
+        candidates[record] = record
+      end
+    end
+
+    def copy_paper_trail_state(from:, to:)
+      return unless from.respond_to?(:paper_trail_whodunnit) && to.respond_to?(:paper_trail_whodunnit)
+
+      to.instance_variable_set(:@paper_trail_whodunnit, from.paper_trail_whodunnit) if from.paper_trail_whodunnit
+
+      from_changes = from.paper_trail_accumulated_versions
+      return if from_changes.blank?
+
+      existing = to.instance_variable_get(:@paper_trail_accumulated_versions) || {}
+      to.instance_variable_set(:@paper_trail_accumulated_versions, existing.merge(from_changes))
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::ConnectionAdapters::Transaction.prepend(PaperTrail::CallbackPropagation)
+end

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -3,8 +3,8 @@
 module PaperTrail
   # mongo_trails captures paper_trail state on the saved instance via after_save (see
   # ModelConfig#paper_trail_accumulate_versions): the accumulated field changes plus a snapshot
-  # of the request context (whodunnit, controller_info, event_group_uuid). It reads that state
-  # back from after_commit to build the version.
+  # of the whole PaperTrail.request context. It reads that state back from after_commit to build
+  # the version.
   #
   # When the same record is saved more than once in a transaction through different in-memory
   # instances, Rails 7.1+ picks ONE instance to fire after_commit on and discards the rest — so
@@ -17,26 +17,18 @@ module PaperTrail
   # the earlier candidate and DROP later instances, we:
   #
   #   * merge every discarded instance's accumulated field changes onto the kept candidate, and
-  #   * copy the captured request context (whodunnit + controller_info + event_group_uuid) of
-  #     the LAST writer onto the kept candidate.
+  #   * hand the kept candidate the captured request context of the LAST writer.
   #
   # The request context is NOT taken from "whichever instance was enrolled in the transaction
   # last": instances are enrolled in first-save order, so when the kept (first) instance is
   # itself re-saved AFTER a later instance, naively copying the later instance's state would
   # clobber the kept instance's own, newer state and attribute the version to the wrong writer
   # (e.g. the wrong automation). Instead we read the full, chronologically-ordered list of saves
-  # to find the genuinely LAST writer of each record.
+  # to find the genuinely LAST writer of each record. The context itself is opaque here: the
+  # model (ModelConfig) owns what is captured and restored, so this code stays agnostic of any
+  # host-app-specific request state.
   module CallbackPropagation
     private
-
-    # Captured request state to copy from the last writer onto the kept instance. Whodunnit is
-    # read back by `RecordTrail#assign_whodunnit!`; the rest is restored around the version
-    # build by `ModelConfig#paper_trail_within_writer_request`.
-    PAPER_TRAIL_STATE_IVARS = %i[
-      @paper_trail_whodunnit
-      @paper_trail_controller_info
-      @paper_trail_event_group_uuid
-    ].freeze
 
     def prepare_instances_to_run_callbacks_on(records)
       # `records` here is the de-duplicated list Rails passes in (`unique_records`). The full,
@@ -64,12 +56,13 @@ module PaperTrail
         candidates[record] = record
       end.tap do |candidates|
         # The kept instance runs after_commit and builds the version. When it is not itself the
-        # last writer, copy the last writer's captured request state (whodunnit, controller_info,
-        # event_group_uuid) onto it so the version reflects the writer it belongs to.
+        # last writer, hand it the last writer's captured request context so the version is
+        # attributed to the writer it belongs to. The context shape is opaque here — the model
+        # owns capture/adopt (ModelConfig) so this stays agnostic of any app-specific state.
         candidates.each_value do |kept|
           next unless kept.class.run_commit_callbacks_on_first_saved_instances_in_transaction
 
-          copy_paper_trail_state(from: last_writers[kept], to: kept)
+          adopt_last_writer_state(into: kept, from: last_writers[kept])
         end
       end
     end
@@ -80,24 +73,17 @@ module PaperTrail
       return {} unless all_saves
 
       all_saves.each_with_object({}) do |record, acc|
-        next unless record.respond_to?(:paper_trail_whodunnit)
+        next unless record.respond_to?(:paper_trail_captured_state, true)
 
         acc[record] = record
       end
     end
 
-    def copy_paper_trail_state(from:, to:)
-      return if from.nil? || from.equal?(to)
-      return unless to.respond_to?(:paper_trail_whodunnit)
+    def adopt_last_writer_state(into:, from:)
+      return if from.nil? || from.equal?(into)
+      return unless from.respond_to?(:paper_trail_captured_state, true) && into.respond_to?(:paper_trail_adopt_state, true)
 
-      PAPER_TRAIL_STATE_IVARS.each do |ivar|
-        next unless from.instance_variable_defined?(ivar)
-
-        value = from.instance_variable_get(ivar)
-        next if value.blank?
-
-        to.instance_variable_set(ivar, value)
-      end
+      into.send(:paper_trail_adopt_state, from.send(:paper_trail_captured_state))
     end
 
     def merge_accumulated_versions(from:, to:)

--- a/lib/mongo_trails/callback_propagation.rb
+++ b/lib/mongo_trails/callback_propagation.rb
@@ -1,107 +1,65 @@
 # frozen_string_literal: true
 
 module PaperTrail
-  # mongo_trails captures paper_trail state on the saved instance via after_save (see
-  # ModelConfig#paper_trail_accumulate_versions): the accumulated field changes plus a snapshot
-  # of the whole PaperTrail.request context. It reads that state back from after_commit to build
-  # the version.
+  # mongo_trails captures paper_trail state on each saved instance via after_save (see
+  # ModelConfig#paper_trail_accumulate_versions): that instance's accumulated field changes plus
+  # a snapshot of the whole PaperTrail.request context at save time.
   #
-  # When the same record is saved more than once in a transaction through different in-memory
-  # instances, Rails 7.1+ picks ONE instance to fire after_commit on and discards the rest — so
-  # any state captured on the discarded instances is lost.
+  # The version is built HERE, from `prepare_instances_to_run_callbacks_on`, which Rails calls
+  # once per transaction commit. We build one version per distinct in-memory instance that
+  # accumulated changes, restoring that instance's captured request context while the version is
+  # built — so the version is attributed to the writer that performed the save (e.g. the specific
+  # automation), not to whatever the request happens to hold at commit time.
   #
-  # Rails' built-in fix propagates `_new_record_before_last_commit` from the earlier candidate
-  # to the later one (active_record/connection_adapters/abstract/transaction.rb). We mirror that
-  # for paper_trail state, in the opposite direction: when
-  # `run_commit_callbacks_on_first_saved_instances_in_transaction = true` causes Rails to KEEP
-  # the earlier candidate and DROP later instances, we:
+  # Building per instance (rather than once per record) is deliberate: when several writers each
+  # load and save the record through their OWN instance in one transaction — the common
+  # multi-automation pattern, including the same set of automations firing again — each writer
+  # gets its own, correctly-attributed version. Rails 7.1+ fires after_commit on only ONE instance
+  # per record (`run_commit_callbacks_on_first_saved_instances_in_transaction`), so building from
+  # after_commit would lose the others; `prepare_instances_to_run_callbacks_on` sees every
+  # instance (`unique_records` is de-duplicated by object identity, not by record identity).
   #
-  #   * merge every discarded instance's accumulated field changes onto the kept candidate, and
-  #   * hand the kept candidate the captured request context of the LAST writer.
-  #
-  # The request context is NOT taken from "whichever instance was enrolled in the transaction
-  # last": instances are enrolled in first-save order, so when the kept (first) instance is
-  # itself re-saved AFTER a later instance, naively copying the later instance's state would
-  # clobber the kept instance's own, newer state and attribute the version to the wrong writer
-  # (e.g. the wrong automation). Instead we read the full, chronologically-ordered list of saves
-  # to find the genuinely LAST writer of each record. The context itself is opaque here: the
-  # model (ModelConfig) owns what is captured and restored, so this code stays agnostic of any
-  # host-app-specific request state.
+  # Non-ActiveRecord objects enrolled in the transaction by other gems (e.g.
+  # after_commit_everywhere's Wrap) are ignored: `merge_accumulated_versions` only acts on objects
+  # exposing `paper_trail_accumulated_versions`, and the Rails dedup branch only reads the AR-only
+  # `run_commit_callbacks_on_first_saved_instances_in_transaction` class attribute when there is an
+  # earlier candidate of the same record (never the case for unique Wrap objects).
   module CallbackPropagation
     private
 
     def prepare_instances_to_run_callbacks_on(records)
-      # `records` here is the de-duplicated list Rails passes in (`unique_records`). The full,
-      # ordered list of saves is `self.records`: a record saved through several in-memory
-      # instances — or the same instance re-saved — appears once per save, in chronological
-      # order. We use it to find the instance that performed the LAST save of each record, so
-      # the version is attributed to it rather than to whichever instance happened to be
-      # enrolled in the transaction last.
-      last_writers = last_writer_by_record(self.records)
-
       records.each_with_object({}) do |record, candidates|
         next unless record.trigger_transactional_callbacks?
 
         earlier_saved_candidate = candidates[record]
 
-        if earlier_saved_candidate && record.class.run_commit_callbacks_on_first_saved_instances_in_transaction
-          merge_accumulated_versions(from: record, to: earlier_saved_candidate)
-          next
-        end
+        # Build this instance's version once the transaction has actually committed. Each
+        # distinct instance gets its own version, attributed to the context captured while it
+        # was saved. Skipped on rollback (`@state.committed?` is false).
+        merge_accumulated_versions(from: record) if @state.committed?
 
+        next if earlier_saved_candidate && record.class.run_commit_callbacks_on_first_saved_instances_in_transaction
         next if earlier_saved_candidate&.destroyed? && !record.destroyed?
 
         record._new_record_before_last_commit = true if earlier_saved_candidate&._new_record_before_last_commit
 
         candidates[record] = record
-      end.tap do |candidates|
-        # The kept instance runs after_commit and builds the version. When it is not itself the
-        # last writer, hand it the last writer's captured request context so the version is
-        # attributed to the writer it belongs to. The context shape is opaque here — the model
-        # owns capture/adopt (ModelConfig) so this stays agnostic of any app-specific state.
-        candidates.each_value do |kept|
-          # `candidates` can include non-ActiveRecord entries enrolled in the transaction by
-          # other gems (e.g. after_commit_everywhere's Wrap). Those respond neither to
-          # PaperTrail's capture/adopt API nor to the AR-only
-          # `run_commit_callbacks_on_first_saved_instances_in_transaction` class attribute, so
-          # touching that attribute on them raises NoMethodError and aborts the commit. Only
-          # PaperTrail-enabled records can adopt writer state — gate on that before reading the
-          # AR class attribute.
-          next unless kept.respond_to?(:paper_trail_adopt_state, true)
-          next unless kept.class.run_commit_callbacks_on_first_saved_instances_in_transaction
-
-          adopt_last_writer_state(into: kept, from: last_writers[kept])
-        end
       end
     end
 
-    # Build { record => last_saved_instance } honouring chronological save order. Later entries
-    # overwrite earlier ones, so the final value is the instance that saved the record last.
-    def last_writer_by_record(all_saves)
-      return {} unless all_saves
-
-      all_saves.each_with_object({}) do |record, acc|
-        next unless record.respond_to?(:paper_trail_captured_state, true)
-
-        acc[record] = record
-      end
-    end
-
-    def adopt_last_writer_state(into:, from:)
-      return if from.nil? || from.equal?(into)
-      return unless from.respond_to?(:paper_trail_captured_state, true) && into.respond_to?(:paper_trail_adopt_state, true)
-
-      into.send(:paper_trail_adopt_state, from.send(:paper_trail_captured_state))
-    end
-
-    def merge_accumulated_versions(from:, to:)
-      return unless from.respond_to?(:paper_trail_accumulated_versions) && to.respond_to?(:paper_trail_accumulated_versions)
+    def merge_accumulated_versions(from:)
+      return unless from.respond_to?(:paper_trail_accumulated_versions)
 
       from_changes = from.paper_trail_accumulated_versions
       return if from_changes.blank?
 
-      existing = to.instance_variable_get(:@paper_trail_accumulated_versions) || {}
-      to.instance_variable_set(:@paper_trail_accumulated_versions, existing.merge(from_changes))
+      from.send(:paper_trail_within_writer_request) do
+        if from.previously_new_record?
+          from.paper_trail.record_create if from.paper_trail.save_version?
+        else
+          from.paper_trail.record_update(force: false, in_after_callback: true, is_touch: false) if from.paper_trail.save_version? # rubocop:disable Style/IfUnlessModifier,Layout/LineLength
+        end
+      end
     end
   end
 end

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -33,12 +33,12 @@ module PaperTrail
         private
 
         # Capture the whole PaperTrail.request context (not just whodunnit) on the saved
-        # instance. The version is built later from after_commit, possibly on a *different*
-        # instance and after the request context that performed the save has been restored, so
-        # the context the version is attributed to has to travel on the instance. We snapshot the
-        # entire request store rather than named fields, so whatever a host app keeps in
-        # PaperTrail.request (whodunnit, controller_info, and any custom keys) is preserved
-        # without this gem knowing about app-specific state.
+        # instance. The version is built later at transaction commit (see
+        # PaperTrail::CallbackPropagation), by which time the request context that performed the
+        # save has been restored, so the context the version is attributed to has to travel on the
+        # instance. We snapshot the entire request store rather than named fields, so whatever a
+        # host app keeps in PaperTrail.request (whodunnit, controller_info, and any custom keys) is
+        # preserved without this gem knowing about app-specific state.
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
           @paper_trail_whodunnit = PaperTrail.request.whodunnit
@@ -74,22 +74,6 @@ module PaperTrail
           end
         end
 
-        # Internal coordination API for PaperTrail::CallbackPropagation: move the captured
-        # context between in-memory instances of the same record within a transaction, without
-        # the propagation having to know which ivars hold it.
-        def paper_trail_captured_state
-          return unless instance_variable_defined?(:@paper_trail_request_state)
-
-          { whodunnit: @paper_trail_whodunnit, request_state: @paper_trail_request_state }
-        end
-
-        def paper_trail_adopt_state(state)
-          return if state.nil?
-
-          @paper_trail_whodunnit = state[:whodunnit]
-          @paper_trail_request_state = state[:request_state]
-        end
-
         def paper_trail_accumulated_version_value(old_value, new_value)
           if old_value.present? && old_value.is_a?(Array) && old_value.size > 1 && new_value.is_a?(Array) && new_value.size > 1 # rubocop:disable Layout/LineLength
             [old_value.first, new_value.last]
@@ -111,7 +95,6 @@ module PaperTrail
         private
 
         def paper_trail_on_record_create_in_transaction
-          paper_trail_within_writer_request { paper_trail.record_create if paper_trail.save_version? }
           paper_trail_clear_accumulated_versions
         end
       end
@@ -131,16 +114,6 @@ module PaperTrail
         end
 
         def paper_trail_on_record_update
-          paper_trail_within_writer_request do
-            if paper_trail.save_version?
-              paper_trail.record_update(
-                force: false,
-                in_after_callback: true,
-                is_touch: false
-              )
-            end
-          end
-
           paper_trail.clear_version_instance
           paper_trail_clear_accumulated_versions
         end

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -124,9 +124,23 @@ module PaperTrail
 
     def on_destroy(_recording_order = 'before')
       @model_class.class_eval do
+        # A destroy never fires `after_save`, so `paper_trail_accumulate_versions` (the after_save
+        # hook that snapshots the request context for create/update) never runs for it. Capture
+        # the context here instead, while the record is being destroyed and PaperTrail.request
+        # still holds the writer's context (whodunnit, event_group_uuid, controller_info and any
+        # host-app keys). The destroy version itself is only built at transaction commit (see
+        # `paper_trail_on_record_destroy_in_transaction`), by which point the writer's context has
+        # been torn down — without this snapshot the version is attributed to whatever the request
+        # happens to hold at commit time, losing its whodunnit and event_group_uuid.
+        before_destroy :paper_trail_capture_destroy_context, prepend: true
         after_commit :paper_trail_on_record_destroy_in_transaction, on: :destroy
 
         private
+
+        def paper_trail_capture_destroy_context
+          @paper_trail_whodunnit = PaperTrail.request.whodunnit
+          @paper_trail_request_state = paper_trail_request_snapshot
+        end
 
         def paper_trail_on_record_destroy_in_transaction
           paper_trail_within_writer_request { paper_trail.record_destroy('before') }

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -25,8 +25,7 @@ module PaperTrail
 
     def on_save
       @model_class.class_eval do
-        attr_reader :paper_trail_accumulated_versions, :paper_trail_whodunnit,
-                    :paper_trail_controller_info, :paper_trail_event_group_uuid
+        attr_reader :paper_trail_accumulated_versions, :paper_trail_whodunnit
 
         after_save :paper_trail_accumulate_versions
         after_rollback :paper_trail_clear_accumulated_versions
@@ -35,14 +34,15 @@ module PaperTrail
 
         # Capture the whole PaperTrail.request context (not just whodunnit) on the saved
         # instance. The version is built later from after_commit, possibly on a *different*
-        # instance and after the request context that performed the save has been restored —
-        # so whodunnit, controller_info (e.g. impersonation / integration) and the app's
-        # event_group_uuid all have to travel on the instance, the same way whodunnit does.
+        # instance and after the request context that performed the save has been restored, so
+        # the context the version is attributed to has to travel on the instance. We snapshot the
+        # entire request store rather than named fields, so whatever a host app keeps in
+        # PaperTrail.request (whodunnit, controller_info, and any custom keys) is preserved
+        # without this gem knowing about app-specific state.
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
           @paper_trail_whodunnit = PaperTrail.request.whodunnit
-          @paper_trail_controller_info = PaperTrail.request.controller_info
-          @paper_trail_event_group_uuid = PaperTrail.request.event_group_uuid if PaperTrail.request.respond_to?(:event_group_uuid)
+          @paper_trail_request_state = paper_trail_request_snapshot
 
           saved_changes.each do |k, new_value|
             old_value = @paper_trail_accumulated_versions[k.to_sym]
@@ -50,18 +50,44 @@ module PaperTrail
           end
         end
 
-        # Restore the captured request context for the duration of the version build so that
-        # everything that reads PaperTrail.request while building the version (whodunnit,
-        # controller_info metadata, event_group_uuid) reflects the writer this version belongs
-        # to, rather than whatever the request happens to hold at commit time.
-        def paper_trail_within_writer_request
-          return yield unless instance_variable_defined?(:@paper_trail_controller_info)
+        # A deep copy of the whole PaperTrail.request store (whodunnit, controller_info and any
+        # host-app keys), or nil if this build of PaperTrail doesn't expose the store.
+        def paper_trail_request_snapshot
+          request = PaperTrail.request
+          request.respond_to?(:to_h, true) ? request.send(:to_h) : nil
+        end
 
-          set_event_group_uuid = PaperTrail.request.respond_to?(:event_group_uuid=)
-          PaperTrail.request.with(whodunnit: @paper_trail_whodunnit, controller_info: @paper_trail_controller_info) do
-            PaperTrail.request.event_group_uuid = @paper_trail_event_group_uuid if set_event_group_uuid
+        # Restore the captured request context for the duration of the version build so that
+        # everything reading PaperTrail.request while building the version reflects the writer
+        # this version belongs to, rather than whatever the request holds at commit time.
+        def paper_trail_within_writer_request
+          snapshot = instance_variable_defined?(:@paper_trail_request_state) ? @paper_trail_request_state : nil
+          request = PaperTrail.request
+          return yield unless snapshot && request.respond_to?(:to_h, true) && request.respond_to?(:set, true)
+
+          previous = request.send(:to_h)
+          request.send(:set, snapshot)
+          begin
             yield
+          ensure
+            request.send(:set, previous)
           end
+        end
+
+        # Internal coordination API for PaperTrail::CallbackPropagation: move the captured
+        # context between in-memory instances of the same record within a transaction, without
+        # the propagation having to know which ivars hold it.
+        def paper_trail_captured_state
+          return unless instance_variable_defined?(:@paper_trail_request_state)
+
+          { whodunnit: @paper_trail_whodunnit, request_state: @paper_trail_request_state }
+        end
+
+        def paper_trail_adopt_state(state)
+          return if state.nil?
+
+          @paper_trail_whodunnit = state[:whodunnit]
+          @paper_trail_request_state = state[:request_state]
         end
 
         def paper_trail_accumulated_version_value(old_value, new_value)

--- a/lib/mongo_trails/model_config.rb
+++ b/lib/mongo_trails/model_config.rb
@@ -25,20 +25,42 @@ module PaperTrail
 
     def on_save
       @model_class.class_eval do
-        attr_reader :paper_trail_accumulated_versions, :paper_trail_whodunnit
+        attr_reader :paper_trail_accumulated_versions, :paper_trail_whodunnit,
+                    :paper_trail_controller_info, :paper_trail_event_group_uuid
 
         after_save :paper_trail_accumulate_versions
         after_rollback :paper_trail_clear_accumulated_versions
 
         private
 
+        # Capture the whole PaperTrail.request context (not just whodunnit) on the saved
+        # instance. The version is built later from after_commit, possibly on a *different*
+        # instance and after the request context that performed the save has been restored —
+        # so whodunnit, controller_info (e.g. impersonation / integration) and the app's
+        # event_group_uuid all have to travel on the instance, the same way whodunnit does.
         def paper_trail_accumulate_versions
           @paper_trail_accumulated_versions ||= {}
           @paper_trail_whodunnit = PaperTrail.request.whodunnit
+          @paper_trail_controller_info = PaperTrail.request.controller_info
+          @paper_trail_event_group_uuid = PaperTrail.request.event_group_uuid if PaperTrail.request.respond_to?(:event_group_uuid)
 
           saved_changes.each do |k, new_value|
             old_value = @paper_trail_accumulated_versions[k.to_sym]
             @paper_trail_accumulated_versions[k.to_sym] = paper_trail_accumulated_version_value(old_value, new_value)
+          end
+        end
+
+        # Restore the captured request context for the duration of the version build so that
+        # everything that reads PaperTrail.request while building the version (whodunnit,
+        # controller_info metadata, event_group_uuid) reflects the writer this version belongs
+        # to, rather than whatever the request happens to hold at commit time.
+        def paper_trail_within_writer_request
+          return yield unless instance_variable_defined?(:@paper_trail_controller_info)
+
+          set_event_group_uuid = PaperTrail.request.respond_to?(:event_group_uuid=)
+          PaperTrail.request.with(whodunnit: @paper_trail_whodunnit, controller_info: @paper_trail_controller_info) do
+            PaperTrail.request.event_group_uuid = @paper_trail_event_group_uuid if set_event_group_uuid
+            yield
           end
         end
 
@@ -63,7 +85,7 @@ module PaperTrail
         private
 
         def paper_trail_on_record_create_in_transaction
-          paper_trail.record_create if paper_trail.save_version?
+          paper_trail_within_writer_request { paper_trail.record_create if paper_trail.save_version? }
           paper_trail_clear_accumulated_versions
         end
       end
@@ -83,12 +105,14 @@ module PaperTrail
         end
 
         def paper_trail_on_record_update
-          if paper_trail.save_version?
-            paper_trail.record_update(
-              force: false,
-              in_after_callback: true,
-              is_touch: false
-            )
+          paper_trail_within_writer_request do
+            if paper_trail.save_version?
+              paper_trail.record_update(
+                force: false,
+                in_after_callback: true,
+                is_touch: false
+              )
+            end
           end
 
           paper_trail.clear_version_instance
@@ -106,7 +130,7 @@ module PaperTrail
         private
 
         def paper_trail_on_record_destroy_in_transaction
-          paper_trail.record_destroy('before')
+          paper_trail_within_writer_request { paper_trail.record_destroy('before') }
           paper_trail_clear_accumulated_versions
         end
       end

--- a/test/transaction_handling_test.rb
+++ b/test/transaction_handling_test.rb
@@ -150,4 +150,25 @@ class TransactionHandlingTest < Minitest::Test
 
     assert_equal 1, user.versions.count
   end
+
+  # A destroy never fires after_save, so the writer context is not captured by the usual
+  # accumulate-on-save path. The destroy version is built at commit time (after_commit on:
+  # :destroy), by which point the request context may have moved on. The context must be
+  # snapshotted while the record is being destroyed (before_destroy) so the version is still
+  # attributed to the writer that destroyed it, not to whatever the request holds at commit time.
+  def test_on_destroy_keeps_writer_whodunnit_when_request_changes_before_commit
+    PaperTrail.request.whodunnit = 'deleter'
+    user = User.create!(name: 'John Doe')
+
+    ActiveRecord::Base.transaction do
+      user.destroy!
+      # Simulate the writer's context being torn down before the outermost transaction commits
+      # (e.g. a service object that resets whodunnit in an ensure block).
+      PaperTrail.request.whodunnit = 'someone-else'
+    end
+
+    destroy_version = user.versions.where(event: 'destroy').last
+    assert_not_nil destroy_version, 'A destroy version should have been created'
+    assert_equal 'deleter', destroy_version.whodunnit
+  end
 end

--- a/test/transaction_handling_test.rb
+++ b/test/transaction_handling_test.rb
@@ -74,6 +74,26 @@ class TransactionHandlingTest < Minitest::Test
     assert_equal([nil, 'Governor'], versions.last.object_changes['title'])
   end
 
+  # When the same record is written through SEVERAL distinct in-memory instances in one
+  # transaction (e.g. several automations each loading and updating it), each instance produces
+  # its own version, attributed to the context captured while that instance was saved — rather
+  # than collapsing every change onto a single version.
+  def test_distinct_instances_each_get_their_own_version
+    user = User.create!(name: 'John Doe')
+    assert_equal 1, user.versions.count
+
+    ActiveRecord::Base.transaction do
+      User.find(user.id).update!(name: 'Jackie Chan')
+      User.find(user.id).update!(title: 'Governor')
+    end
+
+    assert_equal 3, user.versions.count
+    assert_equal %w[create update update], user.versions.pluck(:event)
+    updates = user.versions.where(event: 'update').to_a
+    assert(updates.any? { |v| v.object_changes.keys == %w[name] })
+    assert(updates.any? { |v| v.object_changes.keys == %w[title] })
+  end
+
   def test_on_update_does_not_create_version_if_transaction_not_completed
     user = User.create!(name: 'John Doe')
     assert_equal 1, user.versions.count


### PR DESCRIPTION
## Summary

mongo_trails stashes `@paper_trail_whodunnit` and `@paper_trail_accumulated_versions` onto the saved instance in `after_save` (`ModelConfig#paper_trail_accumulate_versions`) and reads them back from `after_commit` to build the version (`RecordTrail#assign_whodunnit!`). When the same record is saved more than once in a transaction through different in-memory instances, Rails 7.1+ picks **one** instance to fire `after_commit` on and discards the rest — so any state captured on the discarded instance (e.g. inside a `PaperTrail.request.with(whodunnit: ...)` block that wrapped only the second save) is lost. The version ends up with the whodunnit/changes from whichever instance happens to win Rails' dedup, which under `run_commit_callbacks_on_first_saved_instances_in_transaction = true` is the earlier (often unrelated) save.

This PR mirrors Rails' built-in `_new_record_before_last_commit` propagation in `ActiveRecord::ConnectionAdapters::Transaction#prepare_instances_to_run_callbacks_on`, in the opposite direction: when the config is `true` and Rails is about to drop a later instance in favour of the kept earlier candidate, we copy the later instance's `@paper_trail_whodunnit` and merge its `@paper_trail_accumulated_versions` onto the kept candidate first.

With the Rails 7.1+ default (`run_commit_callbacks_on_first_saved_instances_in_transaction = false`) the propagation branch never runs, so this patch is a no-op for the default configuration.

## Reproduction

```ruby
PaperTrail.request.with(whodunnit: 'user_42') do
  ActiveRecord::Base.transaction do
    record = SomeModel.create!(...) # instance A added to txn records
    PaperTrail.request.with(whodunnit: 'System') do
      SomeModel.find(record.id).update!(...) # instance B added to txn records
    end
  end
end
# Expected: version recorded with whodunnit = 'System'
# Actual (with first-wins config): version recorded with whodunnit = 'user_42'
```

## Test plan

- [ ] Verify against an app that opts into `run_commit_callbacks_on_first_saved_instances_in_transaction = true` — versions recorded after `PaperTrail.request.with(whodunnit: ...)` blocks now preserve the wrapping context regardless of which instance fires `after_commit`.
- [ ] Verify against an app using the Rails 7.1+ default (`false`) — no behavioural change.